### PR TITLE
Add DisableJoinLeaveMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Mods on this list are marked as outdated when they are *two* major Minecraft ver
 - [Gestus](https://www.curseforge.com/minecraft/mc-mods/gestus)
 - [Join Messages](https://www.curseforge.com/minecraft/mc-mods/join-messages)
 - [CustomJoinMessagesFabric](https://www.curseforge.com/minecraft/mc-mods/customjoinmessagesfabric)
+- [DisableJoinLeaveMessage](https://github.com/voruti/DisableJoinLeaveMessage)
 - [Image2Map](https://www.curseforge.com/minecraft/mc-mods/image2map)
 - [Chat History](https://www.curseforge.com/minecraft/mc-mods/chat-history)
 - [Command Aliases](https://www.curseforge.com/minecraft/mc-mods/commandaliases)


### PR DESCRIPTION
I weren't able to configure what I wanted with the two mods above this entry. So I programmed this myself.
(As the name suggests) this mod filters all "status messages" and cancels them, if they match a join or leave message.