### PR TITLE
Remove TabPing

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,6 @@ Mods on this list are marked as outdated when they are *two* major Minecraft ver
 - [Server Ping](https://www.curseforge.com/minecraft/mc-mods/serverping)
 - [MiniMOTD](https://www.curseforge.com/minecraft/mc-mods/minimotd-fabric)
 - [Sewing Machine Utilities](https://www.curseforge.com/minecraft/mc-mods/sewing-machine-utilities)
-- [TabPing](https://www.curseforge.com/minecraft/mc-mods/tabping-for-fabric)
 
 ### Tab List modifications
 - [Fabric Tab List](https://modrinth.com/mod/tab)


### PR DESCRIPTION
While checking out some mods i noticed TabPing seems to be gone from curseforge.
I tried to find another source for it but only found a [removed GitHub repo](https://github.com/JackRedstonia/tabping).