### PR TITLE
Add (my?) mod: orereadoutV2, remove original Ore-Readout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -330,7 +330,7 @@
     },
     "simpledotcss": {
       "version": "git+ssh://git@github.com/kevquirk/simple.css.git#b1faa9366a9a34af115da39ddc8fa3dd44f03e07",
-      "from": "simpledotcss@github:kevquirk/simple.css"
+      "from": "simpledotcss@git+https://github.com/kevquirk/simple.css.git"
     },
     "source-map": {
       "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -330,7 +330,7 @@
     },
     "simpledotcss": {
       "version": "git+ssh://git@github.com/kevquirk/simple.css.git#b1faa9366a9a34af115da39ddc8fa3dd44f03e07",
-      "from": "simpledotcss@git+https://github.com/kevquirk/simple.css.git"
+      "from": "simpledotcss@github:kevquirk/simple.css"
     },
     "source-map": {
       "version": "0.6.1",

--- a/src/mods/ore-readout.toml
+++ b/src/mods/ore-readout.toml
@@ -1,5 +1,0 @@
-name = 'Ore-Readout'
-links.modrinth = 'https://modrinth.com/mod/ore-readout'
-categories = [
-	'server-management/logging-auditing',
-]

--- a/src/mods/orereadoutv2.toml
+++ b/src/mods/orereadoutv2.toml
@@ -1,0 +1,5 @@
+name = 'orereadoutV2'
+links.modrinth = 'https://modrinth.com/mod/orereadoutv2'
+categories = [
+	'server-management/logging-auditing',
+]


### PR DESCRIPTION
The original Ore-Readout (see https://modrinth.com/mod/ore-readout) has not been updated in over 3 years.

I took it upon myself to maintain and develop new features for this fork of OreReadout that I named "orereadoutV2". See: https://modrinth.com/mod/orereadoutv2